### PR TITLE
Rename repository & module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="urlextract",  # Replace with your own username
+    name="dealroom-urlextract",  # Replace with your own username
     version="0.0.1",
     author="Dealroom.co",
     author_email="data@dealroom.co",
     description="Wrapper class for extracting only wanted parts from urls.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/dealroom/urlextract",
+    url="https://github.com/dealroom/data-urlextract",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Also renamed the module to be like dealroom-urlextract so it's not confusing with
https://pypi.org/project/urlextract/ when using pip install.

**This might break** the places where this is been used, but it's better to do that now rather than later. It might also not, cause GitHub maintains the redirects to the old names, but I haven't tried this before with git pip modules.