### PR TITLE
Update pip command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Wrapper class for extracting only wanted parts from urls.
 
 ## Install
 
-**pip:**  
-`pip install -e git+https://github.com/dealroom/data-urlextract.git#egg=dealroom-urlextract`
+**pip:**
+`pip install git+https://github.com/dealroom/data-urlextract@main`
 
-**Poetry:**  
+**Poetry:**
 `poetry add "git+https://github.com/dealroom/data-urlextract#main"`
 
 ## Usage


### PR DESCRIPTION
This is a workaround, we have not solved why problem with previous command still persists

**Notes**:

* looks like in this way it is not installed in [editable mode](https://stackoverflow.com/a/29124937)

* also this command would work `pip install git+https://github.com/dealroom/data-urlextract.git#egg=dealroom-urlextract`. So it looks like the problem is in installing it in editable mode (flag `-e`)